### PR TITLE
Fix build issues on 10.15

### DIFF
--- a/OctoMouse.xcodeproj/project.pbxproj
+++ b/OctoMouse.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				fr,
 				de,
@@ -515,8 +516,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_ENTITLEMENTS = OctoMouse/OctoMouse.entitlements;
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OctoMouse/OctoMouse-Prefix.pch";
@@ -535,8 +536,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_ENTITLEMENTS = OctoMouse/OctoMouse.entitlements;
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OctoMouse/OctoMouse-Prefix.pch";

--- a/OctoMouse/OctoMouse.entitlements
+++ b/OctoMouse/OctoMouse.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Nice app! This PR fixes the two issues when cloning & building on macOS 10.15:

* [Sandboxed apps (generally) don't have an ability to request Accessibility privileges](https://stackoverflow.com/questions/32116095/how-to-use-accessibility-with-sandboxed-app/32163397#32163397), blocking keystroke counting.
    * "OctoMouse" did not appear in Security & Privacy > Accessibility access, even after clicking the trigger in the menus and moving to `/Applications`.
    * Removing sandboxing (i.e. setting it to false) allowed the app to appear in Security & Privacy where I could then check its entry to enable keystroke counting.

* Changing signing authority to default ("Sign to Run Locally") instead of "Mac Developer"
   * Otherwise, build will fail if "Mac Developer" is not found
